### PR TITLE
fix(typo): fix typo in parse-full-name library [ch21998]

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ exports.parseFullName = function parseFullName(
                 namePartWords[j].slice(3).toLowerCase();
             } else if (
                 namePartLabels[j] === 'suffix' &&
-                nameParts[j].slice(-1) !== '.' &&
-                !suffixList.indexOf(nameParts[j].toLowerCase())
+                namePartWords[j].slice(-1) !== '.' &&
+                !suffixList.indexOf(namePartWords[j].toLowerCase())
               ) { // Convert suffix abbreviations to UPPER CASE
               if ( namePartWords[j] === namePartWords[j].toLowerCase() ) {
                 namePartWords[j] = namePartWords[j].toUpperCase();


### PR DESCRIPTION
https://app.clubhouse.io/drata/story/21998/autopilot-not-running-post-acute-analytics-access-token-has-expired-or-is-not-yet-valid-and-cannot-read-property-slice-of